### PR TITLE
Add options for exporting to JSON

### DIFF
--- a/blocks_1.12.html
+++ b/blocks_1.12.html
@@ -165,6 +165,9 @@
                     <a role="button" class="btn dropdown-btn btn-default export-csv">
                         <i class="fas fa-file-export"></i>Export CSV
                     </a>
+                    <a role="button" class="btn dropdown-btn btn-default export-json">
+                        <i class="fas fa-file-export"></i>Export JSON
+                    </a>
                 </div>
 
                 <div class="settings-box">

--- a/entities.html
+++ b/entities.html
@@ -178,6 +178,9 @@
                     <a role="button" class="btn dropdown-btn btn-default export-csv">
                         <i class="fas fa-file-export"></i>Export CSV
                     </a>
+                    <a role="button" class="btn dropdown-btn btn-default export-json">
+                        <i class="fas fa-file-export"></i>Export JSON
+                    </a>
                 </div>
 
                 <div class="settings-box">

--- a/index.html
+++ b/index.html
@@ -163,6 +163,9 @@
                     <a role="button" class="btn dropdown-btn btn-default export-csv">
                         <i class="fas fa-file-export"></i>Export CSV
                     </a>
+                    <a role="button" class="btn dropdown-btn btn-default export-json">
+                        <i class="fas fa-file-export"></i>Export JSON
+                    </a>
                 </div>
 
                 <div class="settings-box">

--- a/items.html
+++ b/items.html
@@ -160,6 +160,9 @@
           <a role="button" class="btn dropdown-btn btn-default export-csv">
             <i class="fas fa-file-export"></i>Export CSV
           </a>
+          <a role="button" class="btn dropdown-btn btn-default export-json">
+            <i class="fas fa-file-export"></i>Export JSON
+          </a>
         </div>
 
         <div class="settings-box">

--- a/script.js
+++ b/script.js
@@ -46,7 +46,7 @@ try {
 }
 
 let search = urlParams.get("search") ?? "";
-let page, entry_header, exportable_list;
+let page, entry_header, exportable_list, exportable_data;
 
 function load_data(filename) {
     page = document.body.dataset.page;
@@ -332,6 +332,9 @@ function display_headers_and_table() {
                         <a role="button" class="btn dropdown-btn btn-default export-csv">
                             <i class="fas fa-file-export"></i>Export CSV
                         </a>
+                        <a role="button" class="btn dropdown-btn btn-default export-json">
+                            <i class="fas fa-file-export"></i>Export JSON
+                        </a>
                         <a role="button" class="btn dropdown-btn btn-default copy-comma-separated">
                             <i class="fas fa-copy"></i>Copy Comma-Separated List
                         </a>
@@ -347,6 +350,16 @@ function display_headers_and_table() {
         const link = document.createElement("a");
         link.setAttribute("href", encodedUri);
         link.setAttribute("download", page + "list.csv");
+        document.body.appendChild(link); // Required for FireFox
+
+        link.click();
+    });
+
+    $('.export-json').click(function (e) {
+        const encodedUri = encodeURI("data:application/json;charset=utf-8," + JSON.stringify(exportable_data));
+        const link = document.createElement("a");
+        link.setAttribute("href", encodedUri);
+        link.setAttribute("download", page + "list.json");
         document.body.appendChild(link); // Required for FireFox
 
         link.click();
@@ -620,6 +633,8 @@ function display_results() {
 
     // For exporting as CSV:
     exportable_list = output_data.map(entry => entry[page]);
+	// For exporting as JSON:
+	exportable_data = output_data;
 
     // // For entry count:
     // $('#entry_count').html(output_data.length.toString());


### PR DESCRIPTION
Currently, the only export format available is CSV. This is sufficient for many use cases, but many other cases require having the actual data. This pull request adds an option to export to JSON, which exports the data along with its properties.